### PR TITLE
Turn PoE out to Off to all interfaces

### DIFF
--- a/Omnitik5AC/rooftop-ospf.rsc.tmpl
+++ b/Omnitik5AC/rooftop-ospf.rsc.tmpl
@@ -35,6 +35,7 @@ set use-ip-firewall=yes
 
 /interface ethernet
 set [ find default-name=ether1 ] comment="NN:$nodenumber"
+set [ find ] poe-out=off
 
 /interface wireless security-profiles
 add authentication-types=wpa-psk,wpa2-psk management-protection=allowed mode=\


### PR DESCRIPTION
Find command selects all ethernet interfaces, and sets the PoE Out flag to Off to prevent future issues with PoE detection in the future. Will be updating documentation page after this change.
Discussion in #install-leaders private channel on Slack
https://app.slack.com/client/T02MB96L1/GRZ5NJRMW/thread/G0FS2EVSQ-1638991799.442600