### PR TITLE
Fix sxtsq5ac-kiosk-vpn-ospf.rsc.tmpl configuration for LinkNYC Kiosks

### DIFF
--- a/SXTsq5AC/sxtsq5ac-kiosk-vpn-ospf.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-kiosk-vpn-ospf.rsc.tmpl
@@ -38,12 +38,16 @@ add authentication-types=wpa-psk,wpa2-psk management-protection=allowed mode=\
 /interface wireless security-profiles
 add authentication-types=wpa-eap,wpa2-eap eap-methods=eap-ttls-mschapv2 group-ciphers=tkip,aes-ccm mode=dynamic-keys mschapv2-password=5fsOpxER mschapv2-username=anonymous@citybridge.com name=linknyc supplicant-identity=anonymous@citybridge.com tls-mode=dont-verify-certificate unicast-ciphers=tkip,aes-ccm
 
+/interface wireless security-profiles
+add comment="linkNYC portal (public)" management-protection=allowed name=linknycportal supplicant-identity=MikroTik
 
 /interface wireless
 set [ find default-name=wlan1 ] band=5ghz-a/n/ac channel-width=20/40/80mhz-Ceee country="united states2" default-authentication=no disabled=no frequency=auto security-profile=linknyc ssid="LinkNYC Private" wireless-protocol=802.11
 
 /interface wireless connect-list
-add interface=wlan1 security-profile=linknyc ssid="LinkNYC Private" wireless-protocol=802.11
+add comment="LinkNYC Portal (Public) Network" interface=wlan1 security-profile=linknycportal ssid="LinkNYC Free Wi-Fi" wireless-protocol=802.11
+add comment="LinkNYC Private Network" interface=wlan1 security-profile=linknyc ssid="LinkNYC Private" wireless-protocol=802.11
+add comment="Dont connect to other SSIDS not in connect-list" connect=no interface=wlan1
 
 /interface l2tp-client add allow-fast-path=yes connect-to=l2tpvpn.sn1.mesh.nycmesh.net disabled=no ipsec-secret=nycmeshnet max-mru=1200 max-mtu=1200 keepalive-timeout=disabled name=nycmesh-375p-core2 password=nycmeshnet use-ipsec=yes user=nycmesh
 

--- a/SXTsq5AC/sxtsq5ac-kiosk-vpn-ospf.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-kiosk-vpn-ospf.rsc.tmpl
@@ -53,12 +53,23 @@ add address=($meship . "/16") interface=mesh
 add address=($wdsip . "/16") interface=wds
 
 /ip dhcp-client
-add add-default-route=yes default-route-distance=210 disabled=no interface=wlan1 use-peer-dns=no use-peer-ntp=no script=":local currentGateway [ /ip dhcp-client get [/ip dhcp-client find status=bound ] gateway ]\
-    \n/ip route remove [ /ip route find dst-address=199.167.59.6/32 ]\
+add add-default-route=no interface=wlan1 script="####### MESH SCRIPT for PUBLIC PORTAL ###########\
+    \n/ip route remove [ /ip route find gateway=10.64.0.1 ]\
+    \n/ip route remove [ /ip route find gateway=100.64.0.1 ]\
+    \n/ip route remove [ /ip route find gateway=100.96.0.1 ]\
     \n/ip route remove [ /ip route find dst-address=8.8.8.8/32 ]\
-    \n/ip route add dst-address=199.167.59.6/32 gateway=\$currentGateway\
-    \n/ip route add dst-address=199.170.132.6/32 gateway=\$currentGateway\
-    \n/ip route add dst-address=8.8.8.8/32 gateway=\$currentGateway"
+    \n/ip route remove [ /ip route find dst-address=1.1.1.1/32 ]\
+    \n/ip route add gateway=100.64.0.1 distance=210\
+    \n/ip route add dst-address=0.0.0.0/0 gateway=100.64.0.1 distance=210\
+    \n/ip route add dst-address=199.167.59.6/32 gateway=100.64.0.1 distance=1\
+    \n/ip route add dst-address=199.170.132.6/32 gateway=100.64.0.1 distance=1\
+    \n/ip route add dst-address=199.170.132.4/32 gateway=100.64.0.1 distance=1\
+    \n/ip route add gateway=100.96.0.1 distance=210\
+    \n/ip route add dst-address=0.0.0.0/0 gateway=100.96.0.1 distance=210\
+    \n/ip route add dst-address=199.167.59.6/32 gateway=100.96.0.1 distance=1\
+    \n/ip route add dst-address=199.170.132.6/32 gateway=100.96.0.1 distance=1\
+    \n/ip route add dst-address=199.170.132.4/32 gateway=100.96.0.1 distance=1\
+    \n####### MESH SCRIPT for PUBLIC PORTAL ###########" use-peer-dns=no use-peer-ntp=no
 
 /ip dns set allow-remote-requests=yes
 /ip dns set allow-remote-requests=yes servers=10.10.10.10,8.8.8.8,8.8.4.4


### PR DESCRIPTION
The two commits make the following changes to the sxtsq5ac-kiosk-vpn-ospf.rsc.tmpl configgen:

1. Fixes the default gateway for LinkNYC via DHCP-Client script (https://nycmesh.slack.com/archives/CG9NNSRFH/p1629171828013200)
2. Private SSID no longers works (for mikrotik or iphone or other devices). I have changed the connect-lists to make the public SSID the primary, private as secondary. 