### PR TITLE
Add Target Node NN field to SXT configuration

### DIFF
--- a/SXTsq5AC/sxtsq5ac-mesh-bridge.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-mesh-bridge.rsc.tmpl
@@ -18,7 +18,7 @@ add authentication-types=wpa-psk,wpa2-psk management-protection=allowed mode=\
     wpa-pre-shared-key=nycmeshnet wpa2-pre-shared-key=nycmeshnet
 
 /interface wireless
-set [ find default-name=wlan1 ] band=5ghz-a/n/ac channel-width=20/40/80mhz-Ceee country="united states3" disabled=no distance=dynamic antenna-gain=0 installation=any frequency=5180 mode=station-bridge security-profile=nycmeshnet wireless-protocol=802.11 wps-mode=disabled ssid="nycmesh-xxxx-omni" radio-name=("nycmesh-" . $nodenumber . "-sxt") comment="uses nycmesh-xxxx-omni via bridge"
+set [ find default-name=wlan1 ] band=5ghz-a/n/ac channel-width=20/40/80mhz-Ceee country="united states3" disabled=no distance=dynamic antenna-gain=0 installation=any frequency=5180 mode=station-bridge security-profile=nycmeshnet wireless-protocol=802.11 wps-mode=disabled ssid="nycmesh-{{targetnn}}-omni" radio-name=("nycmesh-" . $nodenumber . "-sxt") comment="uses nycmesh-{{targetnn}}-omni via bridge"
 
 /interface wireless connect-list
 add allow-signal-out-of-range=3s disabled=yes interface=wlan1 security-profile=nycmeshnet signal-range=-75..120


### PR DESCRIPTION
Using targetnn variable, only on mesh bridge config.