### PR TITLE
Add static DNS A record to all OSPF speaking devices

### DIFF
--- a/HAPac2/hap2ac-ospf.rsc.tmpl
+++ b/HAPac2/hap2ac-ospf.rsc.tmpl
@@ -77,6 +77,9 @@ add address=$cidr dns-server=( "10.10.10.10," . $firstip) gateway=$firstip netma
 /ip dns
 set allow-remote-requests=yes servers=10.10.10.10,1.1.1.1
 
+/ip dns static
+add address=$firstip comment="DNS A record for this device" name=n$nodenumber.mesh ttl=5m
+
 /routing ospf instance set [ find default=yes ] router-id=$meship redistribute-connected=as-type-1
 /routing filter add chain="ospf-in" set-bgp-communities=65000:110 set-distance=205
 /routing ospf interface add interface=mesh network-type=ptmp

--- a/Omnitik5AC/omni-only.rsc.tmpl
+++ b/Omnitik5AC/omni-only.rsc.tmpl
@@ -104,6 +104,9 @@ add address=$cidr dns-server=( "10.10.10.10," . $firstip) gateway=$firstip netma
 /ip dns
 set allow-remote-requests=yes servers=10.10.10.10,1.1.1.1
 
+/ip dns static
+add address=$firstip comment="DNS A record for this device" name=n$nodenumber.mesh ttl=5m
+
 :beep frequency=1500 length=100ms
 
 /routing ospf instance set [ find default=yes ] router-id=$meship redistribute-connected=as-type-1

--- a/Omnitik5AC/omni-poe-ether5.rsc.tmpl
+++ b/Omnitik5AC/omni-poe-ether5.rsc.tmpl
@@ -108,6 +108,9 @@ add address=$cidr dns-server=( "10.10.10.10," . $firstip) gateway=$firstip netma
 /ip dns
 set allow-remote-requests=yes servers=10.10.10.10,1.1.1.1
 
+/ip dns static
+add address=$firstip comment="DNS A record for this device" name=n$nodenumber.mesh ttl=5m
+
 :beep frequency=1500 length=100ms
 
 /routing ospf instance set [ find default=yes ] router-id=$meship redistribute-connected=as-type-1

--- a/SXTsq5AC/sxtsq5ac-kiosk-vpn-ospf.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-kiosk-vpn-ospf.rsc.tmpl
@@ -78,6 +78,9 @@ add add-default-route=no interface=wlan1 script="####### MESH SCRIPT for PUBLIC 
 /ip dns set allow-remote-requests=yes
 /ip dns set allow-remote-requests=yes servers=10.10.10.10,8.8.8.8,8.8.4.4
 
+/ip dns static
+add address=$firstip comment="DNS A record for this device" name=n$nodenumber.mesh ttl=5m
+
 /interface bridge port
 add bridge=mesh interface=ether1
 

--- a/SXTsq5AC/sxtsq5ac-mesh-ospf-solo.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-mesh-ospf-solo.rsc.tmpl
@@ -67,6 +67,9 @@ add address=$cidr dns-server=( "10.10.10.10," . $firstip) gateway=$firstip netma
 /ip dns
 set allow-remote-requests=yes servers=10.10.10.10,1.1.1.1
 
+/ip dns static
+add address=$firstip comment="DNS A record for this device" name=n$nodenumber.mesh ttl=5m
+
 /routing ospf instance set [ find default=yes ] router-id=$meship redistribute-connected=as-type-1
 /routing filter add chain="ospf-in" set-bgp-communities=65000:110 set-distance=205
 /routing ospf interface add interface=mesh network-type=ptmp

--- a/SXTsq5AC/sxtsq5ac-mesh-ospf.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-mesh-ospf.rsc.tmpl
@@ -56,6 +56,9 @@ add action=drop chain=forward in-bridge=wds
 /ip dns
 set allow-remote-requests=yes servers=10.10.10.10,1.1.1.1
 
+/ip dns static
+add address=$firstip comment="DNS A record for this device" name=n$nodenumber.mesh ttl=5m
+
 /routing ospf instance set [ find default=yes ] router-id=$meship redistribute-connected=as-type-1
 /routing filter add chain="ospf-in" set-bgp-communities=65000:110 set-distance=205
 /routing ospf interface add interface=mesh network-type=ptmp

--- a/SXTsq5AC/sxtsq5ac-wds-ospf-solo.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-wds-ospf-solo.rsc.tmpl
@@ -67,6 +67,9 @@ add address=$cidr dns-server=( "10.10.10.10," . $firstip) gateway=$firstip netma
 /ip dns
 set allow-remote-requests=yes servers=10.10.10.10,1.1.1.1
 
+/ip dns static
+add address=$firstip comment="DNS A record for this device" name=n$nodenumber.mesh ttl=5m
+
 /routing ospf instance set [ find default=yes ] router-id=$meship redistribute-connected=as-type-1
 /routing filter add chain="ospf-in" set-bgp-communities=65000:110 set-distance=205
 /routing ospf interface add interface=mesh network-type=ptmp

--- a/SXTsq5AC/sxtsq5ac-wds-ospf.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-wds-ospf.rsc.tmpl
@@ -56,6 +56,9 @@ add action=drop chain=forward in-bridge=wds
 /ip dns
 set allow-remote-requests=yes servers=10.10.10.10,1.1.1.1
 
+/ip dns static
+add address=$firstip comment="DNS A record for this device" name=n$nodenumber.mesh ttl=5m
+
 /routing ospf instance set [ find default=yes ] router-id=$meship redistribute-connected=as-type-1
 /routing filter add chain="ospf-in" set-bgp-communities=65000:110 set-distance=205
 /routing ospf interface add interface=mesh network-type=ptmp


### PR DESCRIPTION
This PR adds a static `nXXXX.mesh` DNS `A` record to the default configuration of all OSPF speaking devices which points to the first address in their DHCP range. This will allow you to use `http://nXXXX.mesh` in order to access the management console of the device, mesh-wide.

For example, at NN 3607 we get an A record that maps `n3607.mesh` -> `10.99.133.193`
<img width="574" alt="Screen Shot 2023-03-28 at 18 50 50" src="https://user-images.githubusercontent.com/3138937/228384325-9e12bbf8-ea80-497c-bd2b-502f80e023a0.png">

This works because the `10.10.10.10` DNS resolver is already set up to give an `NS` record pointing `nXXXX.mesh` to that same IP (first valid address in the router's DHCP range). There is already an existing `A` record for `nycmesh-XXXX-rtr.mesh`, but that's too much for my lazy fingers to type and this takes advantage of the existing `NS` record that has already blocked out `nXXXX.mesh` as assigned to the router by creating an apex A record in the zone.