### PR TITLE
Only accept dns requests going to internal IPs

### DIFF
--- a/Omnitik5AC/omni-only-ros7.rsc.tmpl
+++ b/Omnitik5AC/omni-only-ros7.rsc.tmpl
@@ -138,7 +138,7 @@ add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
 add action=accept chain=input protocol=icmp
-add action=accept chain=input dst-port=53 protocol=udp
+add action=accept chain=input dst-port=53 protocol=udp dst-address=10.0.0.0/8
 add action=accept chain=input connection-state=established,related
 add action=drop chain=input in-bridge-port=wlan2
 add action=drop chain=input src-address-list=!meshaddr

--- a/Omnitik5AC/omni-only-ros7.rsc.tmpl
+++ b/Omnitik5AC/omni-only-ros7.rsc.tmpl
@@ -138,7 +138,7 @@ add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
 add action=accept chain=input protocol=icmp
-add action=accept chain=input dst-port=53 protocol=udp dst-address=10.0.0.0/8
+add action=accept chain=input dst-port=53 protocol=udp src-address-list=meshaddr
 add action=accept chain=input connection-state=established,related
 add action=drop chain=input in-bridge-port=wlan2
 add action=drop chain=input src-address-list=!meshaddr

--- a/Omnitik5AC/omni-poe-ether5-ros7.rsc.tmpl
+++ b/Omnitik5AC/omni-poe-ether5-ros7.rsc.tmpl
@@ -142,7 +142,7 @@ add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
 add action=accept chain=input protocol=icmp
-add action=accept chain=input dst-port=53 protocol=udp
+add action=accept chain=input dst-port=53 protocol=udp dst-address=10.0.0.0/8
 add action=accept chain=input connection-state=established,related
 add action=drop chain=input in-bridge-port=wlan2
 add action=drop chain=input src-address-list=!meshaddr

--- a/Omnitik5AC/omni-poe-ether5-ros7.rsc.tmpl
+++ b/Omnitik5AC/omni-poe-ether5-ros7.rsc.tmpl
@@ -142,7 +142,7 @@ add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
 add action=accept chain=input protocol=icmp
-add action=accept chain=input dst-port=53 protocol=udp dst-address=10.0.0.0/8
+add action=accept chain=input dst-port=53 protocol=udp src-address-list=meshaddr
 add action=accept chain=input connection-state=established,related
 add action=drop chain=input in-bridge-port=wlan2
 add action=drop chain=input src-address-list=!meshaddr


### PR DESCRIPTION
## Problem
Because `/ip/dns/allow-remote-requests=yes` and the default firewall rule for port 53 is to allow any traffic (for mesh users to use their omni as a cache) if an omni is given a public IP and no firewall rules are changed, it will respond to DNS requests from the internet. This was being abused in some cases.

## Solution
To make this less error prone, the default firewall rule for port 53 is made to be more restrictive. This is fine in the default case without a public IP, and now volunteers giving out new public IPs don't need to think about DNS.