### PR TITLE
Add historical graphing to ROS6 defaults

### DIFF
--- a/HAPac2/hap2ac-ospf.rsc.tmpl
+++ b/HAPac2/hap2ac-ospf.rsc.tmpl
@@ -21,7 +21,6 @@
 :foreach x in=[/interface wireless find] do={ /interface wireless reset-configuration $x }
 
 /interface bridge
-add auto-mac=yes name=local fast-forward=no 
 add auto-mac=yes name=mesh fast-forward=no protocol-mode=none
 add auto-mac=yes name=wds fast-forward=no protocol-mode=none
 
@@ -34,36 +33,35 @@ add authentication-types=wpa-psk,wpa2-psk management-protection=allowed mode=\
     wpa-pre-shared-key=nycmeshnet wpa2-pre-shared-key=nycmeshnet
 
 /interface wireless
-set [ find default-name=wlan1 ] band=2ghz-b/g/n channel-width=20/40mhz-Ce frequency=auto country="united states3" disabled=no distance=dynamic antenna-gain=2 mode=ap-bridge security-profile=nycmeshnet ssid=("nycmesh-" . $nodenumber . "-hapac2") radio-name=("nycmesh-" . $nodenumber . "-hapac2")  wireless-protocol=802.11 wps-mode=disabled
-set [ find default-name=wlan2 ] band=5ghz-a/n/ac channel-width=20/40/80mhz-Ceee country="united states3" disabled=no distance=dynamic antenna-gain=2 frequency=5180 mode=ap-bridge security-profile=nycmeshnet ssid=("nycmesh-" . $nodenumber . "-hapac2") radio-name=("nycmesh-" . $nodenumber . "-hapac2")  wireless-protocol=802.11 wps-mode=disabled
+set [ find default-name=wlan1 ] band=2ghz-b/g/n channel-width=20/40mhz-Ce frequency=auto country="united states3" disabled=no distance=dynamic antenna-gain=2 mode=ap-bridge security-profile=nycmeshnet ssid=("nycmesh-" . $nodenumber . "-hapac2") radio-name=("nycmesh-" . $nodenumber . "-hapac2")  wireless-protocol=802.11 wps-mode=disabled 
+set [ find default-name=wlan2 ] band=5ghz-a/n/ac channel-width=20/40/80mhz-Ceee country="united states3" disabled=no distance=dynamic antenna-gain=2 frequency=5180 mode=ap-bridge security-profile=nycmeshnet ssid=("nycmesh-" . $nodenumber . "-hapac2") radio-name=("nycmesh-" . $nodenumber . "-hapac2")  wireless-protocol=802.11 wps-mode=disabled default-forwarding=no wps-mode=disabled 
 add disabled=no master-interface=wlan2 name=wlan3 ssid="-NYC Mesh Community WiFi-" wps-mode=disabled
 add disabled=no master-interface=wlan2 name=wlan4 ssid="nycmesh-wds" wds-default-bridge=wds wds-mode=dynamic-mesh wps-mode=disabled security-profile=nycmeshnet
 
 /interface wireless connect-list
-add allow-signal-out-of-range=3s interface=wlan3 security-profile=nycmeshnet signal-range=-75..120
-add connect=no interface=wlan3 security-profile=nycmeshnet signal-range=-120..-75
+add allow-signal-out-of-range=60s interface=wlan3 security-profile=nycmeshnet signal-range=-65..120
+add connect=no interface=wlan3 security-profile=nycmeshnet signal-range=-120..-65
 
 /ip address
-add address=($firstip . "/" . $cidrright) interface=local
+add address=($firstip . "/" . $cidrright) interface=mesh
 add address=($meship . "/16") interface=mesh
 add address=($wdsip . "/16") interface=wds
 
 /interface bridge port
-add bridge=local interface=ether1
-add bridge=local interface=ether2
-add bridge=local interface=ether3
-add bridge=local interface=ether4
+add bridge=mesh interface=ether1
+add bridge=mesh interface=ether2
+add bridge=mesh interface=ether3
+add bridge=mesh interface=ether4
 add bridge=mesh interface=ether5
-add bridge=local interface=wlan1
-add bridge=local interface=wlan2
-add bridge=local interface=wlan3
+add bridge=mesh interface=wlan1
+add bridge=mesh interface=wlan2
+add bridge=mesh interface=wlan3
 add bridge=wds interface=wlan4
 add bridge=wds interface=dynamic internal-path-cost=100 path-cost=100
 
 /interface bridge filter
 add action=drop chain=forward in-bridge=mesh
 add action=drop chain=forward in-bridge=wds
-add action=drop chain=forward in-interface=wlan3
 
 /ip pool
 add name=local ranges=$dhcprange
@@ -88,6 +86,7 @@ set allow-remote-requests=yes servers=10.10.10.10,1.1.1.1
 add address=10.0.0.0/8 list=meshaddr
 add address=199.167.59.0/24 list=meshaddr
 add address=199.170.132.0/24 list=meshaddr
+add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
 add action=accept chain=input protocol=icmp
@@ -107,7 +106,7 @@ set udplite disabled=yes
 set dccp disabled=yes
 set sctp disabled=yes
 
-/snmp set enabled=yes
+/snmp set enabled=no
 
 /system identity set name=("nycmesh-" . $nodenumber . "-hapac2")
 

--- a/HAPac2/hap2ac-ospf.rsc.tmpl
+++ b/HAPac2/hap2ac-ospf.rsc.tmpl
@@ -33,7 +33,7 @@ add authentication-types=wpa-psk,wpa2-psk management-protection=allowed mode=\
     wpa-pre-shared-key=nycmeshnet wpa2-pre-shared-key=nycmeshnet
 
 /interface wireless
-set [ find default-name=wlan1 ] band=2ghz-b/g/n channel-width=20/40mhz-Ce frequency=auto country="united states3" disabled=no distance=dynamic antenna-gain=2 mode=ap-bridge security-profile=nycmeshnet ssid=("nycmesh-" . $nodenumber . "-hapac2") radio-name=("nycmesh-" . $nodenumber . "-hapac2")  wireless-protocol=802.11 wps-mode=disabled 
+set [ find default-name=wlan1 ] band=2ghz-b/g/n channel-width=20/40mhz-Ce frequency=auto country="united states3" disabled=no distance=dynamic antenna-gain=2 mode=ap-bridge security-profile=nycmeshnet ssid=("nycmesh-" . $nodenumber . "-hapac2") radio-name=("nycmesh-" . $nodenumber . "-hapac2")  wireless-protocol=802.11 wps-mode=disabled default-forwarding=no
 set [ find default-name=wlan2 ] band=5ghz-a/n/ac channel-width=20/40/80mhz-Ceee country="united states3" disabled=no distance=dynamic antenna-gain=2 frequency=5180 mode=ap-bridge security-profile=nycmeshnet ssid=("nycmesh-" . $nodenumber . "-hapac2") radio-name=("nycmesh-" . $nodenumber . "-hapac2")  wireless-protocol=802.11 wps-mode=disabled default-forwarding=no wps-mode=disabled 
 add disabled=no master-interface=wlan2 name=wlan3 ssid="-NYC Mesh Community WiFi-" wps-mode=disabled
 add disabled=no master-interface=wlan2 name=wlan4 ssid="nycmesh-wds" wds-default-bridge=wds wds-mode=dynamic-mesh wps-mode=disabled security-profile=nycmeshnet

--- a/HAPac2/hap2ac-ospf.rsc.tmpl
+++ b/HAPac2/hap2ac-ospf.rsc.tmpl
@@ -115,3 +115,5 @@ set sctp disabled=yes
 /system ntp client
 set enabled=yes primary-ntp=10.10.10.123 server-dns-names=0.pool.ntp.org
 
+/tool graphing interface add
+/tool graphing resource add

--- a/Netpower16p/np16_switch.rsc.tmpl
+++ b/Netpower16p/np16_switch.rsc.tmpl
@@ -75,3 +75,6 @@ set 14 forwarding-override=ether16,sfp-sfpplus1,sfp-sfpplus2
 /system clock set time-zone-name=America/New_York time-zone-autodetect=no
 /system ntp client set enabled=yes primary-ntp=10.10.10.123 server-dns-names=0.pool.ntp.org
 
+/tool graphing interface add
+/tool graphing resource add
+

--- a/Omnitik5AC/omni-only.rsc.tmpl
+++ b/Omnitik5AC/omni-only.rsc.tmpl
@@ -119,6 +119,7 @@ set allow-remote-requests=yes servers=10.10.10.10,1.1.1.1
 add address=10.0.0.0/8 list=meshaddr
 add address=199.167.59.0/24 list=meshaddr
 add address=199.170.132.0/24 list=meshaddr
+add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
 add action=accept chain=input protocol=icmp

--- a/Omnitik5AC/omni-only.rsc.tmpl
+++ b/Omnitik5AC/omni-only.rsc.tmpl
@@ -150,6 +150,9 @@ set sctp disabled=yes
 /system ntp client
 set enabled=yes primary-ntp=10.10.10.123 server-dns-names=0.pool.ntp.org
 
+/tool graphing interface add
+/tool graphing resource add
+
 {
 :local currentVersionNumber "1"
 :local scriptNamePrefix "ReEnableBridgeFilters"

--- a/Omnitik5AC/omni-poe-ether5.rsc.tmpl
+++ b/Omnitik5AC/omni-poe-ether5.rsc.tmpl
@@ -123,6 +123,7 @@ set allow-remote-requests=yes servers=10.10.10.10,1.1.1.1
 add address=10.0.0.0/8 list=meshaddr
 add address=199.167.59.0/24 list=meshaddr
 add address=199.170.132.0/24 list=meshaddr
+add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
 add action=accept chain=input protocol=icmp

--- a/Omnitik5AC/omni-poe-ether5.rsc.tmpl
+++ b/Omnitik5AC/omni-poe-ether5.rsc.tmpl
@@ -154,6 +154,9 @@ set sctp disabled=yes
 /system ntp client
 set enabled=yes primary-ntp=10.10.10.123 server-dns-names=0.pool.ntp.org
 
+/tool graphing interface add
+/tool graphing resource add
+
 {
 :local currentVersionNumber "1"
 :local scriptNamePrefix "ReEnableBridgeFilters"

--- a/Omnitik5AC/omni-switch-poe-ether5.rsc.tmpl
+++ b/Omnitik5AC/omni-switch-poe-ether5.rsc.tmpl
@@ -113,6 +113,9 @@ add action=drop chain=forward in-interface=!ether5.29 out-interface-list=\
 /system clock set time-zone-name=America/New_York time-zone-autodetect=no
 /system ntp client set enabled=yes primary-ntp=10.10.10.123 server-dns-names=0.pool.ntp.org
 
+/tool graphing interface add
+/tool graphing resource add
+
 /delay 2
 
 
@@ -120,4 +123,49 @@ add action=drop chain=forward in-interface=!ether5.29 out-interface-list=\
 :delay 200ms;
 :beep frequency=880 length=200ms;
 :delay 200ms;
+:beep frequency=1046 length=200ms;
+:delay 200ms;
+:beep frequency=1175 length=200ms;
+:delay 200ms;
+:beep frequency=1318 length=200ms;
+:delay 200ms;
+:beep frequency=880 length=200ms;
+:delay 200ms;
+:beep frequency=220 length=200ms;
+:delay 200ms;
+:beep frequency=440 length=200ms;
+:delay 200ms;
+:beep frequency=220 length=200ms;
+:delay 200ms;
+:beep frequency=880 length=200ms;
+:delay 200ms;
+:beep frequency=1046 length=200ms;
+:delay 200ms;
+:beep frequency=1175 length=200ms;
+:delay 200ms;
+:beep frequency=1318 length=200ms;
+:delay 200ms;
+:beep frequency=1396 length=200ms;
+:delay 200ms;
+:beep frequency=1318 length=200ms;
+:delay 200ms;
+:beep frequency=1046 length=200ms;
+:delay 200ms;
+:beep frequency=1175 length=200ms;
+:delay 200ms;
+:beep frequency=588 length=200ms;
+:delay 200ms;
+:beep frequency=294 length=200ms;
+:delay 200ms;
+:beep frequency=1175 length=200ms;
+:delay 200ms;
+:beep frequency=1046 length=200ms;
+:delay 200ms;
+:beep frequency=659 length=200ms;
+:delay 200ms;
+:beep frequency=1318 length=200ms;
+:delay 200ms;
+:beep frequency=880 length=200ms;
+:delay 200ms;
+:beep frequency=220 length=200ms;
 

--- a/Omnitik5AC/omni-switch-poe-ether5.rsc.tmpl
+++ b/Omnitik5AC/omni-switch-poe-ether5.rsc.tmpl
@@ -39,7 +39,7 @@ add comment="wds passthrough" interface=ether5 name=ether5.29 vlan-id=29
 /interface wireless add disabled=no master-interface=wlan1 name=wlan3 ssid="nycmesh-wds" wds-default-bridge=wds wds-mode=dynamic-mesh wps-mode=disabled security-profile=nycmeshnet
 /interface wireless add comment="uses nycmesh-xxxx-omni via mesh bridge" disabled=yes master-interface=wlan1 mode=station-bridge name=wlan4 security-profile=nycmeshnet ssid=nycmesh-xxxx-omni wds-default-bridge=mesh
 
-/interface wireless connect-list add allow-signal-out-of-range=60s interface=wlan3 security-profile=nycmeshnet signal-range=-65..120
+/interface wireless connect-list add allow-signal-out-of-range=5m interface=wlan3 security-profile=nycmeshnet signal-range=-65..120
 /interface wireless connect-list add connect=no interface=wlan3 security-profile=nycmeshnet signal-range=-120..-65
 
 :beep frequency=900 length=100ms

--- a/SXTsq5AC/sxtsq5ac-core-with-omni.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-core-with-omni.rsc.tmpl
@@ -107,3 +107,6 @@ set sctp disabled=yes
 /system clock set time-zone-name=America/New_York time-zone-autodetect=no
 
 /system ntp client set enabled=yes primary-ntp=10.10.10.123 server-dns-names=0.pool.ntp.org
+
+/tool graphing interface add
+/tool graphing resource add

--- a/SXTsq5AC/sxtsq5ac-kiosk-vpn-ospf.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-kiosk-vpn-ospf.rsc.tmpl
@@ -113,6 +113,7 @@ add address=$cidr dns-server=("10.10.10.10," . $firstip) gateway=$firstip netmas
 add address=10.0.0.0/8 list=meshaddr
 add address=199.167.59.0/24 list=meshaddr
 add address=199.170.132.0/24 list=meshaddr
+add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
 add action=accept chain=input connection-state=established,related,untracked

--- a/SXTsq5AC/sxtsq5ac-kiosk-vpn-ospf.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-kiosk-vpn-ospf.rsc.tmpl
@@ -148,6 +148,8 @@ set sctp disabled=yes
 /system ntp client
 set enabled=yes primary-ntp=10.10.10.123 server-dns-names=0.pool.ntp.org
 
+/tool graphing interface add
+/tool graphing resource add
 
 /tool netwatch add down-script="/ip dhcp-client release 0" host=8.8.8.8 interval=2m timeout=2s
 

--- a/SXTsq5AC/sxtsq5ac-mesh-bridge.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-mesh-bridge.rsc.tmpl
@@ -58,7 +58,7 @@ set udplite disabled=yes
 set dccp disabled=yes
 set sctp disabled=yes
 
-/snmp set enabled=yno
+/snmp set enabled=no
 
 /system identity set name=("nycmesh-" . $nodenumber . "-sxt")
 

--- a/SXTsq5AC/sxtsq5ac-mesh-bridge.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-mesh-bridge.rsc.tmpl
@@ -65,3 +65,5 @@ set sctp disabled=yes
 /system ntp client
 set enabled=yes primary-ntp=10.10.10.123 server-dns-names=0.pool.ntp.org
 
+/tool graphing interface add
+/tool graphing resource add

--- a/SXTsq5AC/sxtsq5ac-mesh-bridge.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-mesh-bridge.rsc.tmpl
@@ -39,6 +39,7 @@ set allow-remote-requests=yes servers=10.10.10.10,1.1.1.1
 add address=10.0.0.0/8 list=meshaddr
 add address=199.167.59.0/24 list=meshaddr
 add address=199.170.132.0/24 list=meshaddr
+add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
 add action=accept chain=input protocol=icmp
@@ -57,7 +58,7 @@ set udplite disabled=yes
 set dccp disabled=yes
 set sctp disabled=yes
 
-/snmp set enabled=yes
+/snmp set enabled=yno
 
 /system identity set name=("nycmesh-" . $nodenumber . "-sxt")
 

--- a/SXTsq5AC/sxtsq5ac-mesh-ospf-solo.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-mesh-ospf-solo.rsc.tmpl
@@ -79,6 +79,7 @@ set allow-remote-requests=yes servers=10.10.10.10,1.1.1.1
 add address=10.0.0.0/8 list=meshaddr
 add address=199.167.59.0/24 list=meshaddr
 add address=199.170.132.0/24 list=meshaddr
+add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
 add action=accept chain=input protocol=icmp
@@ -97,7 +98,7 @@ set udplite disabled=yes
 set dccp disabled=yes
 set sctp disabled=yes
 
-/snmp set enabled=yes
+/snmp set enabled=no
 
 /system identity set name=("nycmesh-" . $nodenumber . "-sxt")
 

--- a/SXTsq5AC/sxtsq5ac-mesh-ospf-solo.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-mesh-ospf-solo.rsc.tmpl
@@ -105,3 +105,6 @@ set sctp disabled=yes
 /system ntp client
 set enabled=yes primary-ntp=10.10.10.123 server-dns-names=0.pool.ntp.org
 
+/tool graphing interface add
+/tool graphing resource add
+

--- a/hEXPOE/hEXPOE_Switch.rsc.tmpl
+++ b/hEXPOE/hEXPOE_Switch.rsc.tmpl
@@ -68,6 +68,9 @@ set 4 forwarding-override=ether1
 /system clock set time-zone-name=America/New_York time-zone-autodetect=no
 /system ntp client set enabled=yes primary-ntp=10.10.10.123 server-dns-names=0.pool.ntp.org
 
+/tool graphing interface add
+/tool graphing resource add
+
 /delay 2
 
 :beep frequency=220 length=200ms;


### PR DESCRIPTION
Enable the graphing by default that allows long-term traffic quantity graphs on a per-port, per-vlan basis

For example, NN584 http://10.69.5.84/graphs/ and NN3654 http://10.69.36.54/graphs/

<img width="989" height="638" alt="image" src="https://github.com/user-attachments/assets/89b11087-7a11-48c3-b4c3-77b6c83731c1" />

<img width="980" height="638" alt="image" src="https://github.com/user-attachments/assets/08576959-c43b-4b95-a63d-37198ee7742d" />

Kernkraft was also added to the switch-only Omni because it was missing 🎧

