### PR TITLE
Update RouterOS 7 Configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Omnitik5AC/test-omni-only-ros7.rsc.tmpl
+++ b/Omnitik5AC/test-omni-only-ros7.rsc.tmpl
@@ -154,11 +154,9 @@ set pptp disabled=yes
 
 /system identity set name=("nycmesh-" . $nodenumber . "-omni")
 
-/system logging
-add action=rsyslog topics=!dhcp,!debug,!packet,!dns,!snmp,!route,!account
-
-/system logging action
-add name=rsyslog remote=10.70.90.56 target=remote
+# Set up syslog reporting
+/system logging action add name=rsyslog remote=10.70.90.56 target=remote
+/system logging add action=rsyslog topics=!dhcp,!debug,!packet,!dns,!snmp,!route,!account
 
 /system clock set time-zone-name=America/New_York time-zone-autodetect=no
 

--- a/Omnitik5AC/test-omni-only-ros7.rsc.tmpl
+++ b/Omnitik5AC/test-omni-only-ros7.rsc.tmpl
@@ -111,14 +111,9 @@ add disabled=no interfaces=all
 
 :beep frequency=1600 length=100ms
 
-/routing/filter/rule
-add chain=ospf-in disabled=no rule="set distance 205;\
-    \nset bgp-communities 65000:110;\
-    \naccept;"
-add chain=ospf-out disabled=no rule="if (dst == 10.69.0.0/16) {\
-    \n  reject\
-    \n}"
-add chain=ospf-out disabled=no rule=accept
+/routing filter rule add chain=ospf-in disabled=no rule=accept
+/routing filter rule add chain=ospf-out disabled=no rule="if (dst == 10.69.0.0/16) {reject;}"
+/routing filter rule add chain=ospf-out disabled=no rule=accept
 
 /routing ospf instance
 add disabled=no in-filter-chain=ospf-in name=default originate-default=never out-filter-chain=ospf-out redistribute=connected router-id=$meship
@@ -127,8 +122,8 @@ add disabled=no in-filter-chain=ospf-in name=default originate-default=never out
 add disabled=no instance=default name=backbone
 
 /routing ospf interface-template
-add area=backbone comment="mesh bridge" cost=10 disabled=no interfaces=mesh networks=10.69.0.0/16 priority=1 type=ptmp-broadcast use-bfd=yes
-add area=backbone comment="wds bridge" cost=100 disabled=no interfaces=wds networks=10.68.0.0/16 priority=1 type=ptmp-broadcast use-bfd=yes
+add area=backbone comment="mesh bridge" cost=10 disabled=no interfaces=mesh networks=10.69.0.0/16 priority=1 type=ptmp-broadcast use-bfd=no
+add area=backbone comment="wds bridge" cost=100 disabled=no interfaces=wds networks=10.68.0.0/16 priority=1 type=ptmp-broadcast use-bfd=no
 
 /ip firewall address-list
 add address=10.0.0.0/8 list=meshaddr
@@ -170,24 +165,54 @@ add name=rsyslog remote=10.70.90.56 target=remote
 /system note
 set show-at-login=yes note="WARNING: This device is using a configuration/firmware combination from the testing branch. For any troubleshooting or configuration support, consult the #software-firmware channel on Slack."
 
-/system ntp client servers
-add address=10.10.10.123
+/system ntp client set enabled=yes
+/system ntp client servers add address=10.10.10.123
 
 /tool graphing interface add
 /tool graphing resource add
 
 /system scheduler
 add interval=15s name=exstart_check on-event=exstart_repair policy=ftp,reboot,read,write,policy,test,password,sniff,sensitive,romon start-date=2024-01-15 start-time=21:11:00
+
 /system script
-add dont-require-permissions=no name=exstart_repair owner=admin policy=ftp,reboot,read,write,policy,test,password,sniff,sensitive,romon source=":local badNeighbor [/routing/ospf/neighbor/get [:pick [/routing/ospf/neighbor/find state=\"ExStart\"] 0 1] address]\
+add comment="OSPF Bad Neighbor Fix" dont-require-permissions=no name=exstart_repair owner=admin policy=ftp,reboot,read,write,policy,test,password,sniff,sensitive,romon source="# exstart_repair\
+    \n# reestablish OSPF links stuck in ExStart\
+    \n#\
+    \n# marg's 2024-10 updates to daniel's script\
     \n\
-    \n:log error \"Bad Neighbor Found: \$badNeighbor\"\
+    \n:local debug \"\";\
+    \n#:set debug \"_debug\"; #uncomment this line to turn on debugging\
     \n\
-    \n/routing/filter/rule/add chain=ospf-in place-before=0 rule=\"if (dst == \$badNeighbor/32) { reject }\"\
+    \n:local scriptName \"exstart_repair\$debug\";\
+    \n:local neighborNum \"\";\
+    \n:local badNeighbor \"\";\
     \n\
-    \n:delay 5000ms\
+    \ndo {\
+    \n  do {\
+    \n    :set neighborNum [:pick [/routing/ospf/neighbor/find state=\"ExStart\"] 0 1];\
+    \n  } on-error { :log warning \"\$scriptName: no matches\"; }\
+    \n    \
     \n\
-    \n/routing/filter/rule/remove [find chain=ospf-in rule=\"if (dst == \$badNeighbor/32) { reject }\"]"
+    \n  :set badNeighbor \\\
+    \n    [/routing/ospf/neighbor/get number=\$neighborNum value-name=address]; # find neighbors in a bad way\
+    \n  :log warning \"\$scriptName: Bad Neighbor Found: \$badNeighbor\";\
+    \n\
+    \n  do {\
+    \n    /routing/filter/rule/add chain=ospf-in place-before=0 rule=\"if (dst == \$badNeighbor/32) { reject }\";\
+    \n    :log warning \"\$scriptName: Rejecting Bad Neighbor \$badNeighbor for 5 seconds\";\
+    \n  } on-error { :log error \"\$scriptName: could not add reject rule\" }; # add a rule to reject neighbor\
+    \n\
+    \n  :delay 5000ms; # wait 5 seconds\
+    \n\
+    \n  do {\
+    \n    /routing/filter/rule/remove [find chain=ospf-in rule=\"if (dst == \$badNeighbor/32) { reject }\"];\
+    \n    :log warning \"\$scriptName: Allowing Bad Neighbor \$badNeighbor to establish adjacency\";\
+    \n  } on-error { :log error \"\$scriptName: could not remove reject rule\" }; # remove rule so it can try again\
+    \n\
+    \n} on-error {\
+    \n  :if (\$debug != \"\") do={:log info \"\$scriptName: nothing to do\";}; # do not set \$debug to stop spamming log\
+    \n}"
+
 
 {
 :local currentVersionNumber "1"
@@ -208,6 +233,30 @@ add name="$fullScriptName" \
 /system scheduler
 add name=run-1h interval=1h on-event="$fullScriptName"
 }
+
+/system script
+add name=low-memory.reboot policy= ftp,reboot,read,write,policy,test,password,sniff,sensitive \
+    dont-require-permissions=yes \
+    comment="reboot on low memory  (set at 75% used)" \
+    source= {
+# reboot on low free memory
+# low-memory.reboot
+# reboot on low memory  (set at 75% used)
+:global ztime [/system clock get time]
+:global freemem [/system resource get free-memory]
+:global totalmem [/system resource get total-memory]
+:global perme (100 * $freemem / $totalmem);
+:log info message=("Percentage of Free Memory: $perme % and Used Memory: $(100-$perme) %")
+# limit 33554432 free = 75% used then reboot between 2 and 3am
+# limit 40165376 free = 70% used
+# limit 53687091 free = 60% used
+# limit 67108864 free = 50% used
+:if ($ztime > 02:00:00 and $ztime < 03:00:00) \
+     do=[:if ($freemem < 33554432) do=[/system reboot]] \
+        else={:log info message=("Time is $ztime and free memory $freemem > 33554432 $(100-$perme) % used")}
+}
+/system scheduler
+add name=low-memory.reboot interval=00:15:00 on-event=low-memory.reboot disabled=no start-time=startup
 
 /delay 2
 

--- a/Omnitik5AC/test-omni-only-ros7.rsc.tmpl
+++ b/Omnitik5AC/test-omni-only-ros7.rsc.tmpl
@@ -1,10 +1,10 @@
 # NYC Mesh Mikrotik Omnitik config
 # Omnitik 5AC RouterOS 7 TEST BUILD NO PoE
-:global nodenumber {{network_number}}
+:global networknumber {{network_number}}
 
-:global cidr ("10." . ((96+(nodenumber>>10))+0) . "." . (((nodenumber>>2)&255)+0) . "." . (((nodenumber&3)<<6)+0) . "/26")
-:global ipthirdoctet ( [ :pick $nodenumber ([:len $nodenumber] - 5) ([:len $nodenumber] - 2) ] + 0 )
-:global ipfourthoctet ( [ :pick $nodenumber ([:len $nodenumber] - 2) ([:len $nodenumber]) ] + 0 )
+:global cidr ("10." . ((96+(networknumber>>10))+0) . "." . (((networknumber>>2)&255)+0) . "." . (((networknumber&3)<<6)+0) . "/26")
+:global ipthirdoctet ( [ :pick $networknumber ([:len $networknumber] - 5) ([:len $networknumber] - 2) ] + 0 )
+:global ipfourthoctet ( [ :pick $networknumber ([:len $networknumber] - 2) ([:len $networknumber]) ] + 0 )
 
 :global cidrleft [ :pick $cidr 0 ( [ :find $cidr "/" ] ) ]
 :global cidrright [ :pick $cidr (( [ :find $cidr "/" ] )+1) 100 ]
@@ -34,7 +34,7 @@ set use-ip-firewall=yes
 :beep frequency=700 length=100ms
 
 /interface/ethernet
-set [ find default-name=ether1 ] comment="NN:$nodenumber"
+set [ find default-name=ether1 ] comment="NN:$networknumber"
 
 /interface/wireless/security-profiles
 add authentication-types=wpa-psk,wpa2-psk management-protection=allowed mode=\
@@ -44,7 +44,7 @@ add authentication-types=wpa-psk,wpa2-psk management-protection=allowed mode=\
 :beep frequency=800 length=100ms
 
 /interface/wireless
-set [ find default-name=wlan1 ] band=5ghz-a/n/ac channel-width=20/40/80mhz-Ceee country="united states3" disabled=no distance=dynamic antenna-gain=0 installation=any frequency=5180 mode=ap-bridge security-profile=nycmeshnet ssid=("nycmesh-" . $nodenumber . "-omni") radio-name=("nycmesh-" . $nodenumber . "-omni")  wireless-protocol=802.11 wps-mode=disabled rx-chains=0,1 tx-chains=0,1 default-forwarding=no
+set [ find default-name=wlan1 ] band=5ghz-a/n/ac channel-width=20/40/80mhz-Ceee country="united states3" disabled=no distance=dynamic antenna-gain=0 installation=any frequency=5180 mode=ap-bridge security-profile=nycmeshnet ssid=("nycmesh-" . $networknumber . "-omni") radio-name=("nycmesh-" . $networknumber . "-omni")  wireless-protocol=802.11 wps-mode=disabled rx-chains=0,1 tx-chains=0,1 default-forwarding=no
 add disabled=no master-interface=wlan1 name=wlan2 ssid="-NYC Mesh Community WiFi-" wps-mode=disabled
 add disabled=no master-interface=wlan1 name=wlan3 ssid="nycmesh-wds" wds-default-bridge=wds wds-mode=dynamic-mesh wps-mode=disabled security-profile=nycmeshnet
 add comment="uses nycmesh-xxxx-omni via mesh bridge" disabled=yes master-interface=wlan1 mode=station-bridge name=wlan4 security-profile=nycmeshnet ssid=nycmesh-xxxx-omni wds-default-bridge=mesh
@@ -152,7 +152,7 @@ set pptp disabled=yes
 
 :beep frequency=1800 length=100ms
 
-/system identity set name=("nycmesh-" . $nodenumber . "-omni")
+/system identity set name=("nycmesh-" . $networknumber . "-omni")
 
 # Set up syslog reporting
 /system logging action add name=rsyslog remote=10.70.90.56 target=remote

--- a/Omnitik5AC/test-omni-poe-ether5-ros7.rsc.tmpl
+++ b/Omnitik5AC/test-omni-poe-ether5-ros7.rsc.tmpl
@@ -115,14 +115,9 @@ add disabled=no interfaces=all
 
 :beep frequency=1600 length=100ms
 
-/routing/filter/rule
-add chain=ospf-in disabled=no rule="set distance 205;\
-    \nset bgp-communities 65000:110;\
-    \naccept;"
-add chain=ospf-out disabled=no rule="if (dst == 10.69.0.0/16) {\
-    \n  reject\
-    \n}"
-add chain=ospf-out disabled=no rule=accept
+/routing filter rule add chain=ospf-in disabled=no rule=accept
+/routing filter rule add chain=ospf-out disabled=no rule="if (dst == 10.69.0.0/16) {reject;}"
+/routing filter rule add chain=ospf-out disabled=no rule=accept
 
 /routing ospf instance
 add disabled=no in-filter-chain=ospf-in name=default originate-default=never out-filter-chain=ospf-out redistribute=connected router-id=$meship
@@ -131,8 +126,8 @@ add disabled=no in-filter-chain=ospf-in name=default originate-default=never out
 add disabled=no instance=default name=backbone
 
 /routing ospf interface-template
-add area=backbone comment="mesh bridge" cost=10 disabled=no interfaces=mesh networks=10.69.0.0/16 priority=1 type=ptmp-broadcast use-bfd=yes
-add area=backbone comment="wds bridge" cost=100 disabled=no interfaces=wds networks=10.68.0.0/16 priority=1 type=ptmp-broadcast use-bfd=yes
+add area=backbone comment="mesh bridge" cost=10 disabled=no interfaces=mesh networks=10.69.0.0/16 priority=1 type=ptmp-broadcast use-bfd=no
+add area=backbone comment="wds bridge" cost=100 disabled=no interfaces=wds networks=10.68.0.0/16 priority=1 type=ptmp-broadcast use-bfd=no
 
 /ip firewall address-list
 add address=10.0.0.0/8 list=meshaddr
@@ -174,24 +169,97 @@ add name=rsyslog remote=10.70.90.56 target=remote
 /system note
 set show-at-login=yes note="WARNING: This device is using a configuration/firmware combination from the testing branch. For any troubleshooting or configuration support, consult the #software-firmware channel on Slack."
 
-/system ntp client servers
-add address=10.10.10.123
+/system ntp client set enabled=yes
+/system ntp client servers add address=10.10.10.123
 
 /tool graphing interface add
 /tool graphing resource add
 
 /system scheduler
 add interval=15s name=exstart_check on-event=exstart_repair policy=ftp,reboot,read,write,policy,test,password,sniff,sensitive,romon start-date=2024-01-15 start-time=21:11:00
+
 /system script
-add dont-require-permissions=no name=exstart_repair owner=admin policy=ftp,reboot,read,write,policy,test,password,sniff,sensitive,romon source=":local badNeighbor [/routing/ospf/neighbor/get [:pick [/routing/ospf/neighbor/find state=\"ExStart\"] 0 1] address]\
+add comment="OSPF Bad Neighbor Fix" dont-require-permissions=no name=exstart_repair owner=admin policy=ftp,reboot,read,write,policy,test,password,sniff,sensitive,romon source="# exstart_repair\
+    \n# reestablish OSPF links stuck in ExStart\
+    \n#\
+    \n# marg's 2024-10 updates to daniel's script\
     \n\
-    \n:log error \"Bad Neighbor Found: \$badNeighbor\"\
+    \n:local debug \"\";\
+    \n#:set debug \"_debug\"; #uncomment this line to turn on debugging\
     \n\
-    \n/routing/filter/rule/add chain=ospf-in place-before=0 rule=\"if (dst == \$badNeighbor/32) { reject }\"\
+    \n:local scriptName \"exstart_repair\$debug\";\
+    \n:local neighborNum \"\";\
+    \n:local badNeighbor \"\";\
     \n\
-    \n:delay 5000ms\
+    \ndo {\
+    \n  do {\
+    \n    :set neighborNum [:pick [/routing/ospf/neighbor/find state=\"ExStart\"] 0 1];\
+    \n  } on-error { :log warning \"\$scriptName: no matches\"; }\
+    \n    \
     \n\
-    \n/routing/filter/rule/remove [find chain=ospf-in rule=\"if (dst == \$badNeighbor/32) { reject }\"]"
+    \n  :set badNeighbor \\\
+    \n    [/routing/ospf/neighbor/get number=\$neighborNum value-name=address]; # find neighbors in a bad way\
+    \n  :log warning \"\$scriptName: Bad Neighbor Found: \$badNeighbor\";\
+    \n\
+    \n  do {\
+    \n    /routing/filter/rule/add chain=ospf-in place-before=0 rule=\"if (dst == \$badNeighbor/32) { reject }\";\
+    \n    :log warning \"\$scriptName: Rejecting Bad Neighbor \$badNeighbor for 5 seconds\";\
+    \n  } on-error { :log error \"\$scriptName: could not add reject rule\" }; # add a rule to reject neighbor\
+    \n\
+    \n  :delay 5000ms; # wait 5 seconds\
+    \n\
+    \n  do {\
+    \n    /routing/filter/rule/remove [find chain=ospf-in rule=\"if (dst == \$badNeighbor/32) { reject }\"];\
+    \n    :log warning \"\$scriptName: Allowing Bad Neighbor \$badNeighbor to establish adjacency\";\
+    \n  } on-error { :log error \"\$scriptName: could not remove reject rule\" }; # remove rule so it can try again\
+    \n\
+    \n} on-error {\
+    \n  :if (\$debug != \"\") do={:log info \"\$scriptName: nothing to do\";}; # do not set \$debug to stop spamming log\
+    \n}"
+
+{
+:local currentVersionNumber "1"
+:local scriptNamePrefix "ReEnableBridgeFilters"
+:local fullScriptName "$scriptNamePrefix_v$currentVersionNumber"
+
+/system script
+# Add bridge filter script
+add name="$fullScriptName" \
+    comment="Managed by ansible" \
+    policy=read,write \
+    source="# Managed by ansible\r\
+    \n:foreach fil in=[/interface bridge filter find disabled=yes action=drop chain=forward] do={\r\
+    \n:log info \"Re-enabling bridge filter \$fil\"\r\
+    \n/interface bridge filter set disabled=no \$fil\r\
+    \n}"
+
+/system scheduler
+add name=run-1h interval=1h on-event="$fullScriptName"
+}
+
+/system script
+add name=low-memory.reboot policy= ftp,reboot,read,write,policy,test,password,sniff,sensitive \
+    dont-require-permissions=yes \
+    comment="reboot on low memory  (set at 75% used)" \
+    source= {
+# reboot on low free memory
+# low-memory.reboot
+# reboot on low memory  (set at 75% used)
+:global ztime [/system clock get time]
+:global freemem [/system resource get free-memory]
+:global totalmem [/system resource get total-memory]
+:global perme (100 * $freemem / $totalmem);
+:log info message=("Percentage of Free Memory: $perme % and Used Memory: $(100-$perme) %")
+# limit 33554432 free = 75% used then reboot between 2 and 3am
+# limit 40165376 free = 70% used
+# limit 53687091 free = 60% used
+# limit 67108864 free = 50% used
+:if ($ztime > 02:00:00 and $ztime < 03:00:00) \
+     do=[:if ($freemem < 33554432) do=[/system reboot]] \
+        else={:log info message=("Time is $ztime and free memory $freemem > 33554432 $(100-$perme) % used")}
+}
+/system scheduler
+add name=low-memory.reboot interval=00:15:00 on-event=low-memory.reboot disabled=no start-time=startup
 
 /delay 2
 

--- a/Omnitik5AC/test-omni-poe-ether5-ros7.rsc.tmpl
+++ b/Omnitik5AC/test-omni-poe-ether5-ros7.rsc.tmpl
@@ -158,11 +158,9 @@ set pptp disabled=yes
 
 /system identity set name=("nycmesh-" . $nodenumber . "-omni")
 
-/system logging
-add action=rsyslog topics=!dhcp,!debug,!packet,!dns,!snmp,!route,!account
-
-/system logging action
-add name=rsyslog remote=10.70.90.56 target=remote
+# Set up syslog reporting
+/system logging action add name=rsyslog remote=10.70.90.56 target=remote
+/system logging add action=rsyslog topics=!dhcp,!debug,!packet,!dns,!snmp,!route,!account
 
 /system clock set time-zone-name=America/New_York time-zone-autodetect=no
 

--- a/Omnitik5AC/test-omni-poe-ether5-ros7.rsc.tmpl
+++ b/Omnitik5AC/test-omni-poe-ether5-ros7.rsc.tmpl
@@ -1,10 +1,10 @@
 # NYC Mesh Mikrotik Omnitik config
 # Omnitik 5AC RouterOS 7 TEST BUILD with Port 5 PoE Enabled
-:global nodenumber {{network_number}}
+:global networknumber {{network_number}}
 
-:global cidr ("10." . ((96+(nodenumber>>10))+0) . "." . (((nodenumber>>2)&255)+0) . "." . (((nodenumber&3)<<6)+0) . "/26")
-:global ipthirdoctet ( [ :pick $nodenumber ([:len $nodenumber] - 5) ([:len $nodenumber] - 2) ] + 0 )
-:global ipfourthoctet ( [ :pick $nodenumber ([:len $nodenumber] - 2) ([:len $nodenumber]) ] + 0 )
+:global cidr ("10." . ((96+(networknumber>>10))+0) . "." . (((networknumber>>2)&255)+0) . "." . (((networknumber&3)<<6)+0) . "/26")
+:global ipthirdoctet ( [ :pick $networknumber ([:len $networknumber] - 5) ([:len $networknumber] - 2) ] + 0 )
+:global ipfourthoctet ( [ :pick $networknumber ([:len $networknumber] - 2) ([:len $networknumber]) ] + 0 )
 
 :global cidrleft [ :pick $cidr 0 ( [ :find $cidr "/" ] ) ]
 :global cidrright [ :pick $cidr (( [ :find $cidr "/" ] )+1) 100 ]
@@ -34,7 +34,7 @@ set use-ip-firewall=yes
 :beep frequency=700 length=100ms
 
 /interface/ethernet
-set [ find default-name=ether1 ] comment="NN:$nodenumber"
+set [ find default-name=ether1 ] comment="NN:$networknumber"
 set [ find default-name=ether2 ] poe-out=off
 set [ find default-name=ether3 ] poe-out=off
 set [ find default-name=ether4 ] poe-out=off
@@ -48,7 +48,7 @@ add authentication-types=wpa-psk,wpa2-psk management-protection=allowed mode=\
 :beep frequency=800 length=100ms
 
 /interface/wireless
-set [ find default-name=wlan1 ] band=5ghz-a/n/ac channel-width=20/40/80mhz-Ceee country="united states3" disabled=no distance=dynamic antenna-gain=0 installation=any frequency=5180 mode=ap-bridge security-profile=nycmeshnet ssid=("nycmesh-" . $nodenumber . "-omni") radio-name=("nycmesh-" . $nodenumber . "-omni")  wireless-protocol=802.11 wps-mode=disabled rx-chains=0,1 tx-chains=0,1 default-forwarding=no
+set [ find default-name=wlan1 ] band=5ghz-a/n/ac channel-width=20/40/80mhz-Ceee country="united states3" disabled=no distance=dynamic antenna-gain=0 installation=any frequency=5180 mode=ap-bridge security-profile=nycmeshnet ssid=("nycmesh-" . $networknumber . "-omni") radio-name=("nycmesh-" . $networknumber . "-omni")  wireless-protocol=802.11 wps-mode=disabled rx-chains=0,1 tx-chains=0,1 default-forwarding=no
 add disabled=no master-interface=wlan1 name=wlan2 ssid="-NYC Mesh Community WiFi-" wps-mode=disabled
 add disabled=no master-interface=wlan1 name=wlan3 ssid="nycmesh-wds" wds-default-bridge=wds wds-mode=dynamic-mesh wps-mode=disabled security-profile=nycmeshnet
 add comment="uses nycmesh-xxxx-omni via mesh bridge" disabled=yes master-interface=wlan1 mode=station-bridge name=wlan4 security-profile=nycmeshnet ssid=nycmesh-xxxx-omni wds-default-bridge=mesh
@@ -156,7 +156,7 @@ set pptp disabled=yes
 
 :beep frequency=1800 length=100ms
 
-/system identity set name=("nycmesh-" . $nodenumber . "-omni")
+/system identity set name=("nycmesh-" . $networknumber . "-omni")
 
 # Set up syslog reporting
 /system logging action add name=rsyslog remote=10.70.90.56 target=remote

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Configuration templates for NYC Mesh
 
-These configs drive [configgen.nycmesh.net](https://configgen.nycmesh.net). The tool[nycmesh-configgen](https://github.com/nycmeshnet/nycmesh-configgen) uses Github Releases to determine which configs are available. Don't forget to create a [new release](https://github.com/nycmeshnet/nycmesh-configs/releases) after merging changes!
+These configs drive the [configgen.nycmesh.net](https://configgen.nycmesh.net) website. The website's code [nycmesh-configgen](https://github.com/nycmeshnet/nycmesh-configgen) uses Git Tags to determine which configs are available. Don't forget to create a [new tag](https://github.com/nycmeshnet/nycmesh-configs/tags) after merging changes! GitHub Releases are not used.  


### PR DESCRIPTION
@matthewjboyd  had some comments in https://github.com/nycmeshnet/nycmesh-configs/pull/45#issuecomment-3148812497 that the RouterOS 7 configs were out of date and needed some tweaking.

Changes:

- Tweak OSPF routing filter rules to remove distance and remove BGP reference
- Disable BFD on the default OSPF interfaces
- Fix an error on config deployment related to syslog, where the out-of-order commands caused an error `input does not match any value of action`
-  Update NTP syntax
- Update the OSPF bad neighbor script with the updated version from Slack from 2024-10 
- Add the low memory reboot script copied over from the routeros6 
- Replace references to `nodenumber` with `networknumber`

____

Testing:

- Flashed the non-PoE and PoE versions to a PoE Omni and confirmed I got to the Kernkraft song. 
  - I downloaded the template file, replaced `{{network_number}}` with `8166` (a test network number, aka above 8000 but below 8192 aka 2^13), renamed the file and removed `.tmpl` from the end, uploaded to the Omni inside the `flash/` directory, and then ran a System/Reset Configuration with keep user, no default, no backup checked, as well as adding the uploaded file to the Run After Reset textbox
- Confirmed the flashed Omni did WDS meshing with my NN666 Omni and was able to access the internet
- Submitting this PR via nycmesh-8166-omni Wifi network! 