### PR TITLE
Make SXT-core config use base NN as IP (stop adding 100)

### DIFF
--- a/SXTsq5AC/sxtsq5ac-core-with-omni.rsc.tmpl
+++ b/SXTsq5AC/sxtsq5ac-core-with-omni.rsc.tmpl
@@ -14,8 +14,8 @@
 :global firstip ($subnet+1)
 :global lastip ($subnet + (~($subnet|$netmask)) - 1)
 :global dhcprange (($firstip+5) . "-" . ($lastip-5))
-:global meship ("10.69." . $ipthirdoctet . "." . (100 + $ipfourthoctet))
-:global wdsip ("10.68." . $ipthirdoctet . "." . (100 + $ipfourthoctet))
+:global meship ("10.69." . $ipthirdoctet . "." . $ipfourthoctet)
+:global wdsip ("10.68." . $ipthirdoctet . "." . $ipfourthoctet)
 
 /delay 2
 


### PR DESCRIPTION
This removes adding 100 to the final octet of the assigned IP address when using a SXT as the core router. 

Adding 100 should be reserved for a second router at a node, whereas, in this config, the SXT is meant to act as the primary (core) router. Without this change, the standard IP address for a given node will not resolve.

This does mean, however, that in the case of a node upgrade, the original core router (likely an OmniTik) should be converted to the switch config _before_ this SXT core router is deployed or there will be an IP address conflict.