### PR TITLE
Add IP firewall comments and new ACCEPT rule for RouterOS 7.23+

### DIFF
--- a/Omnitik5AC/omni-only.rsc.tmpl
+++ b/Omnitik5AC/omni-only.rsc.tmpl
@@ -122,11 +122,12 @@ add address=199.170.132.0/24 list=meshaddr
 add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
-add action=accept chain=input protocol=icmp
-add action=accept chain=input dst-port=53 protocol=udp src-address-list=meshaddr
-add action=accept chain=input connection-state=established,related
-add action=drop chain=input in-bridge-port=wlan2
-add action=drop chain=input src-address-list=!meshaddr
+add action=accept chain=input comment="Accept traffic from mesh public and private IPs" src-address-list=meshaddr
+add action=accept chain=input comment="Accept any ping" protocol=icmp
+add action=accept chain=input comment="Accept any DNS" dst-port=53 protocol=udp src-address-list=meshaddr
+add action=accept chain=input comment="Accept any in-progress established or related connection" connection-state=established,related
+add action=drop chain=input comment="Drop bridge traffic from Free Wifi" in-bridge-port=wlan2
+add action=drop chain=input comment="Drop traffic from non-mesh addressed" src-address-list=!meshaddr
 
 :beep frequency=1700 length=100ms
 

--- a/Omnitik5AC/omni-poe-ether5.rsc.tmpl
+++ b/Omnitik5AC/omni-poe-ether5.rsc.tmpl
@@ -126,11 +126,12 @@ add address=199.170.132.0/24 list=meshaddr
 add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
-add action=accept chain=input protocol=icmp
-add action=accept chain=input dst-port=53 protocol=udp src-address-list=meshaddr
-add action=accept chain=input connection-state=established,related
-add action=drop chain=input in-bridge-port=wlan2
-add action=drop chain=input src-address-list=!meshaddr
+add action=accept chain=input comment="Accept traffic from mesh public and private IPs" src-address-list=meshaddr
+add action=accept chain=input comment="Accept any ping" protocol=icmp
+add action=accept chain=input comment="Accept any DNS" dst-port=53 protocol=udp src-address-list=meshaddr
+add action=accept chain=input comment="Accept any in-progress established or related connection" connection-state=established,related
+add action=drop chain=input comment="Drop bridge traffic from Free Wifi" in-bridge-port=wlan2
+add action=drop chain=input comment="Drop traffic from non-mesh addressed" src-address-list=!meshaddr
 
 :beep frequency=1700 length=100ms
 

--- a/Omnitik5AC/test-omni-only-ros7.rsc.tmpl
+++ b/Omnitik5AC/test-omni-only-ros7.rsc.tmpl
@@ -132,11 +132,12 @@ add address=199.170.132.0/24 list=meshaddr
 add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
-add action=accept chain=input protocol=icmp
-add action=accept chain=input dst-port=53 protocol=udp src-address-list=meshaddr
-add action=accept chain=input connection-state=established,related
-add action=drop chain=input in-bridge-port=wlan2
-add action=drop chain=input src-address-list=!meshaddr
+add action=accept chain=input comment="Accept traffic from mesh public and private IPs" src-address-list=meshaddr
+add action=accept chain=input comment="Accept any ping" protocol=icmp
+add action=accept chain=input comment="Accept any DNS" dst-port=53 protocol=udp src-address-list=meshaddr
+add action=accept chain=input comment="Accept any in-progress established or related connection" connection-state=established,related
+add action=drop chain=input comment="Drop bridge traffic from Free Wifi" in-bridge-port=wlan2
+add action=drop chain=input comment="Drop traffic from non-mesh addressed" src-address-list=!meshaddr
 
 :beep frequency=1700 length=100ms
 

--- a/Omnitik5AC/test-omni-poe-ether5-ros7.rsc.tmpl
+++ b/Omnitik5AC/test-omni-poe-ether5-ros7.rsc.tmpl
@@ -136,11 +136,12 @@ add address=199.170.132.0/24 list=meshaddr
 add address=23.158.16.0/24 list=meshaddr
 
 /ip firewall filter
-add action=accept chain=input protocol=icmp
-add action=accept chain=input dst-port=53 protocol=udp src-address-list=meshaddr
-add action=accept chain=input connection-state=established,related
-add action=drop chain=input in-bridge-port=wlan2
-add action=drop chain=input src-address-list=!meshaddr
+add action=accept chain=input comment="Accept traffic from mesh public and private IPs" src-address-list=meshaddr
+add action=accept chain=input comment="Accept any ping" protocol=icmp
+add action=accept chain=input comment="Accept any DNS" dst-port=53 protocol=udp src-address-list=meshaddr
+add action=accept chain=input comment="Accept any in-progress established or related connection" connection-state=established,related
+add action=drop chain=input comment="Drop bridge traffic from Free Wifi" in-bridge-port=wlan2
+add action=drop chain=input comment="Drop traffic from non-mesh addressed" src-address-list=!meshaddr
 
 :beep frequency=1700 length=100ms
 


### PR DESCRIPTION
To recap, after an update on my VPN-connected omni, I could ping the Omni from elsewhere in the mesh but couldn't SSH or otherwise connect to it. Turns out that sometime between ROS7.21 and 7.24, the default IP->Firewall->Filters rule became DROP rather than ACCEPT  (this happened to OSPF filter rules a while back according to [@Matthew Boyd](https://nycmesh.slack.com/team/U060Q4D822K)) which means any traffic that was not an ICMP ping would get dropped after the update. Reverting to 7.21 fixed the issue, despite the config exports looking identical.

The solution was to add a new  IP->Firewall->Filters rule to the top of the list that explicitly allows source IPs owned by Mesh to have their traffic accepted. `ip/firewall/filter/add action=accept chain=input comment="explicitly accept traffic from mesh public and private IPs"  src-address-list=meshaddr  is the solution to this.



Now, my full set of IP filters (not OSPF filters) is as follows:

```
# 2026-07-29 09:29:00 by RouterOS 7.24rc3
# software id = S2JV-454I
#
# model = RBOmniTikPG-5HacD
# serial number = C70A0CC9B140
/ip firewall filter
add action=accept chain=input comment="explicitly accept traffic from mesh public and private IPs" src-address-list=meshaddr
add action=accept chain=input comment="Allow ICMP pings from anywhere" protocol=icmp
add action=accept chain=input comment="Allow DNS port 53 requests from anywhere" dst-port=53 protocol=udp
add action=accept chain=input comment="Allow established and related connections to pass through" connection-state=established,related
add action=drop chain=input comment="Drop traffic on WLAN2" in-bridge-port=wlan2
add action=drop chain=input comment="Drop traffic from any IP that is not a public or private Mesh IP" src-address-list=!meshaddr
```